### PR TITLE
Adds modified getStateCorrs sub-function to icatb_postprocess_dfc_roi.m

### DIFF
--- a/GroupICATv4.0c/icatb/icatb_helper_functions/icatb_postprocess_dfc_roi.m
+++ b/GroupICATv4.0c/icatb/icatb_helper_functions/icatb_postprocess_dfc_roi.m
@@ -230,7 +230,7 @@ for nFD = 1:length(outputFiles)
     clusterInfo.num_clusters = current_no_clusters;
     
     % Save state-wise windowed corrs and subject-wise state vectors
-    [clusterInfo.corrs_states, clusterInfo.states] = getStateCorr(dfncInfo, clusterInfo); 
+    [clusterInfo.corrs_states, clusterInfo.states] = getStateCorr(dfcRoiInfo, clusterInfo); 
     
     if (strcmpi(analysisType, 'roi-voxel'))
         clusterFiles = cell(1, current_no_clusters);


### PR DESCRIPTION
Adds modified getStateCorrs sub-function (originally found in icatb_post_process_dfnc.m) to roi-based dFC post-processing. Adds call to getStateCorrs after kmeans clustering is run on the full input dataset (all subjects and windows). This provides users with two additional fields (corrs_state and states) in clusterInfo which are needed for group or individual subject analyses.